### PR TITLE
Changed the default RNG.

### DIFF
--- a/doc/toml.md
+++ b/doc/toml.md
@@ -1005,23 +1005,6 @@ could define multiple trajectory writers.
             potential_list = [0, 1]
     ```
 
-- **`is_restart_file`**:
-
-    **If Mandatory**: no
-
-    **Type**: `bool`
-
-    **Default Value**: `false`
-
-    **Dependency**: `format = "h5"`
-
-    **Descriptions**: If this is a restart file writer. If this key is set to
-    `true`, only settings of the `prefix` and `interval` key will be kept,
-    and settings of other keys will be ignored.
-
-    **Notes**: The restart file only contains one frame, and will be named
-    `prefix.restart.h5`.
-
 - **`use_float64`**:
 
     **If Mandatory**: no
@@ -1084,10 +1067,6 @@ could define multiple trajectory writers.
         prefix = "train"
         write_forces = true
         potential_list = [0, 1]
-[[trajectory]]
-        format = "h5"
-        interval = 100
-        is_restart_file = true
 ```
 
 ## The `[[logger]]` array. <a name="logger"></a>

--- a/somd/apps/active_learning.py
+++ b/somd/apps/active_learning.py
@@ -545,9 +545,7 @@ class ACTIVELEARNING(_mdapps.simulations.STAGEDSIMULATION):
         _os.chdir(cwd)
 
     def __train(
-        self,
-        n_iter: int,
-        restart_files: _tp.List[str] = None
+        self, n_iter: int, restart_files: _tp.List[str] = None
     ) -> None:
         """
         Train the model.

--- a/somd/apps/barostats.py
+++ b/somd/apps/barostats.py
@@ -62,7 +62,7 @@ class BAROSTAT(_apputils.post_step.POSTSTEPOBJ):
         self,
         pressures: _tp.List[float],
         beta: _tp.List[float],
-        relaxation_time: float
+        relaxation_time: float,
     ) -> None:
         """
         Create a BAROSTAT instance.

--- a/somd/apps/parser.py
+++ b/somd/apps/parser.py
@@ -143,7 +143,6 @@ class TOMLPARSER(object):
         'potential_list': __value__([list], False, None),
         'use_float64': __value__([bool], False, __dep__('format', ['h5'])),
         'energy_shift': __value__([float], False, __dep__('format', ['exyz'])),
-        'is_restart_file': __value__([bool], False, __dep__('format', ['h5'])),
     }
     __parameters__['logger'] = {
         'format': __value__([str], False, None),
@@ -1070,19 +1069,6 @@ class TOMLPARSER(object):
         """
         Check trajectory settings.
         """
-        has_restart_flag = False
-        for trajectory in self.__trajectories:
-            if hasattr(trajectory, 'is_restart') and trajectory.is_restart:
-                has_restart_flag = True
-                break
-        if not has_restart_flag:
-            self.__trajectories.append(
-                _mdapps.trajectories.H5WRITER(
-                    self.__root['run']['label'] + '.restart.h5',
-                    interval=10,
-                    restart_file=True,
-                )
-            )
         if self.__root['active_learning'] is not None:
             self.__trajectories = []
             message = (
@@ -1122,10 +1108,7 @@ class TOMLPARSER(object):
                 else:
                     interval = table['interval']
                 if trajectory_format == 'h5':
-                    if table['is_restart_file']:
-                        file_name = prefix + '.restart.h5'
-                    else:
-                        file_name = prefix + '.trajectory.h5'
+                    file_name = prefix + '.trajectory.h5'
                     writer = _mdapps.trajectories.H5WRITER(
                         file_name,
                         interval=interval,
@@ -1134,7 +1117,6 @@ class TOMLPARSER(object):
                         write_forces=bool(table['write_forces']),
                         wrap_positions=bool(table['wrap_positions']),
                         append=bool(self.__root['run']['restart_from']),
-                        restart_file=bool(table['is_restart_file']),
                         use_double=bool(table['use_float64']),
                         potential_list=table['potential_list'],
                     )

--- a/somd/apps/simulations.py
+++ b/somd/apps/simulations.py
@@ -65,7 +65,6 @@ class SIMULATION(object):
         self.__system = system
         self.__loggers = loggers
         self.__integrator = integrator
-        self.__restarted = False
         self.__read_force = False
         self.__initialized = False
         self.__post_step_objects = []
@@ -179,7 +178,6 @@ class SIMULATION(object):
         read_step : bool
             If inherit the simulation step from the restart file.
         """
-        self.__restarted = True
         t = _mdapps.trajectories.H5READER(file_name, **kwargs)
         t.bind_integrator(self.__integrator)
         # Read data.

--- a/somd/apps/simulations.py
+++ b/somd/apps/simulations.py
@@ -396,8 +396,9 @@ class STAGEDSIMULATION(_ab.ABC):
 
     @_cl.contextmanager
     def _set_up_simulation(
-        self, potential_indices: _tp.List[int],
-        extra_potentials: _tp.List[_mdcore.potential_base.POTENTIAL] = []
+        self,
+        potential_indices: _tp.List[int],
+        extra_potentials: _tp.List[_mdcore.potential_base.POTENTIAL] = [],
     ) -> SIMULATION:
         """
         Set up a simulation protocol using the given data.

--- a/somd/apps/trajectories.py
+++ b/somd/apps/trajectories.py
@@ -23,8 +23,6 @@ The trajectory writters.
 import os as _os
 import h5py as _h5
 import numpy as _np
-import pickle as _pl
-import base64 as _bs
 import typing as _tp
 from somd import core as _mdcore
 from somd import utils as _mdutils
@@ -297,10 +295,8 @@ class H5WRITER(_apputils.post_step.POSTSTEPOBJ):
         """
         Write RNG data to the trajectory.
         """
-        st = _np.random.get_state()
-        st_str = _bs.b64encode(_pl.dumps(st)).decode('utf-8')
         self.__root['randomState'][0] = '\0' * 10000
-        self.__root['randomState'][0] = st_str
+        self.__root['randomState'][0] = _mdutils.rng.state_string
 
     def bind_integrator(
         self, integrator: _mdcore.integrators.INTEGRATOR
@@ -828,11 +824,11 @@ class H5READER(object):
         Read and set RNG data.
         """
         if 'randomState' in self.__root.keys():
-            st_str = self.__root['randomState'][0].strip()
-            _np.random.set_state(_pl.loads(_bs.b64decode(st_str)))
+            random_state = self.__root['randomState'][0].strip()
+            _mdutils.rng.set_state_from_string(random_state)
         elif 'randomState' in self.__root.attrs.keys():
-            st_str = self.__root.attrs['randomState']
-            _np.random.set_state(_pl.loads(_bs.b64decode(st_str)))
+            random_state = self.__root.attrs['randomState']
+            _mdutils.rng.set_state_from_string(random_state)
         else:
             message = (
                 'Can not load RNG data from a trajectory '

--- a/somd/apps/utils/nep.py
+++ b/somd/apps/utils/nep.py
@@ -58,7 +58,7 @@ def cat_exyz(set_in: _tp.List[str], set_out: str) -> None:
 
 def get_potentials_msd(
     potentials: _tp.List[_mdcore.potential_base.POTENTIAL],
-    system: _mdcore.systems.MDSYSTEM
+    system: _mdcore.systems.MDSYSTEM,
 ) -> float:
     """
     Return the maximum standard deviation of the forces calculated by

--- a/somd/core/groups.py
+++ b/somd/core/groups.py
@@ -146,9 +146,7 @@ class ATOMGROUP(object):
             if energy_new != 0:
                 self.velocities *= _np.sqrt(energy_old / energy_new)
 
-    def add_velocities_from_temperature(
-        self, temperature: float, rng: _np.random.Generator = None
-    ) -> None:
+    def add_velocities_from_temperature(self, temperature: float) -> None:
         """
         Add velocities to atoms in the group according to the given
         temperature.
@@ -157,8 +155,6 @@ class ATOMGROUP(object):
         ----------
         temperature : float
             The initial temperature. In unit of (K).
-        rng : numpy.random.Generator
-            The pseudorandom number generator instance.
         """
         if self.n_dof == 0:
             message = 'Number of DOF of group "{}" has not been calculated!'
@@ -169,10 +165,7 @@ class ATOMGROUP(object):
         factors = _np.sqrt(
             temperature * _mdutils.constants.BOLTZCONST / self.masses
         )
-        if rng is None:
-            v = _mdutils.rng.standard_normal((self.n_atoms, 3)) * factors
-        else:
-            v = rng.standard_normal((self.n_atoms, 3)) * factors
+        v = _mdutils.rng.standard_normal((self.n_atoms, 3)) * factors
         # remove COM translational motions
         v -= (v * self.masses).sum(axis=0) / self.masses.sum()
         # remove COM rotational motions

--- a/somd/core/groups.py
+++ b/somd/core/groups.py
@@ -170,7 +170,7 @@ class ATOMGROUP(object):
             temperature * _mdutils.constants.BOLTZCONST / self.masses
         )
         if rng is None:
-            v = _np.random.standard_normal((self.n_atoms, 3)) * factors
+            v = _mdutils.rng.standard_normal((self.n_atoms, 3)) * factors
         else:
             v = rng.standard_normal((self.n_atoms, 3)) * factors
         # remove COM translational motions

--- a/somd/core/integrators.py
+++ b/somd/core/integrators.py
@@ -700,8 +700,8 @@ class INTEGRATOR(object):
             self.__gamma = self.__rng.standard_gamma
             self.__randn = self.__rng.standard_normal
         else:
-            self.__gamma = _np.random.standard_gamma
-            self.__randn = _np.random.standard_normal
+            self.__gamma = _mdutils.rng.standard_gamma
+            self.__randn = _mdutils.rng.standard_normal
 
 
 def vv_integrator(timestep: float) -> INTEGRATOR:

--- a/somd/utils/__init__.py
+++ b/somd/utils/__init__.py
@@ -20,6 +20,10 @@
 Common utils.
 """
 
+from . import _rng
 from . import warning
 from . import defaults
 from . import constants
+
+# The global RNG in SOMD.
+rng = _rng.RNG()

--- a/somd/utils/_rng.py
+++ b/somd/utils/_rng.py
@@ -1,0 +1,115 @@
+#
+# SOMD is an ab-initio molecular dynamics package designed for the SIESTA code.
+# Copyright (C) 2023 github.com/initqp
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Wrapper of NumPy's RNGs.
+"""
+
+import numpy as _np
+import pickle as _pl
+import base64 as _bs
+
+__all__ = ['RNG', 'LEGACYRNG']
+
+
+class RNG(_np.random.Generator):
+    """
+    Wrapper of NumPy's RNGs.
+
+    Parameters
+    ----------
+    generator_name : str
+        Name of the generator.
+    seed : int
+        The seed value.
+    """
+
+    def __init__(
+        self, generator_name: str = 'PCG64', seed: int = None
+    ) -> None:
+        """
+        Set up the RNG.
+        """
+        self.__generator_name = generator_name
+        generator = eval('_np.random.{:s}'.format(generator_name))(seed)
+        super().__init__(generator)
+
+    def seed(self, seed: int):
+        """
+        Re-seeding the RNG.
+
+        Parameters
+        ----------
+        seed : int
+            The seed value.
+        """
+        rng = RNG(self.__generator_name, seed)
+        self.bit_generator.state = rng.bit_generator.state
+
+    def set_state_from_string(self, state_string: str) -> None:
+        """
+        Set RNG state from string.
+
+        Parameters
+        ----------
+        state_string : str
+            The state string returned by the `state_string` property.
+        """
+        self.bit_generator.state = _pl.loads(_bs.b64decode(state_string))
+
+    @property
+    def state_string(self) -> str:
+        """
+        The state string.
+        """
+        state = self.bit_generator.state
+        return _bs.b64encode(_pl.dumps(state)).decode('utf-8')
+
+
+class LEGACYRNG(_np.random.RandomState):
+    """
+    Wrapper of NumPy's legacy RNGs.
+
+    Parameters
+    ----------
+    seed : int
+        The seed value.
+
+    Notes
+    -----
+    This class is for testing only, and will be removed in future.
+    """
+
+    def set_state_from_string(self, state_string: str) -> None:
+        """
+        Set RNG state from string.
+
+        Parameters
+        ----------
+        state_string : str
+            The state string returned by the `state_string` property.
+        """
+        self.set_state(_pl.loads(_bs.b64decode(state_string)))
+
+    @property
+    def state_string(self) -> str:
+        """
+        The state string.
+        """
+        state = self.get_state()
+        return _bs.b64encode(_pl.dumps(state)).decode('utf-8')

--- a/tests/data/parser/1.toml
+++ b/tests/data/parser/1.toml
@@ -48,5 +48,6 @@
 [run]
 	seed = 1
 	label = "C2H6"
+	_legacy_rng = true
 	restart_from = "data/active_learning/traj.h5"
 	n_steps = 500

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -8,7 +8,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_active_learning_1():

--- a/tests/test_barostat.py
+++ b/tests/test_barostat.py
@@ -6,7 +6,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_barostat_1():

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -6,6 +6,8 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
+
 
 def test_operators():
     system = _h.get_harmonic_system()
@@ -122,7 +124,7 @@ def test_initlization():
     _nt.assert_almost_equal(system.groups[0].temperature, result, DECIMAL_D)
     result = _np.zeros(3, dtype=_np.double)
     _nt.assert_almost_equal(system.groups[0].com_velocities, result, DECIMAL_D)
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
 
 
 def test_com():

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -259,6 +259,44 @@ def test_gbaoab_copy_system():
     _nt.assert_almost_equal(system.velocities, result[4:8], DECIMAL_D)
 
 
+def test_gbaoab_seeding():
+    somd.utils.rng.seed(1)
+    system = _h.get_harmonic_system()
+    c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
+         {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
+         {'type': 2, 'indices': [0, 1, 2, 3], 'target': 0, 'tolerance': 1E-14}]
+    system.constraints.appends(c)
+    integrator = somd.core.integrators.gbaoab_integrator(
+        0.0005, relaxation_times=[0.01])
+    integrator.bind_system(system)
+    integrator.propagate()
+    system = _h.get_harmonic_system()
+    c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
+         {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
+         {'type': 2, 'indices': [0, 1, 2, 3], 'target': 0, 'tolerance': 1E-14}]
+    system.constraints.appends(c)
+    integrator.bind_system(system)
+    integrator.propagate()
+    result = _np.loadtxt('data/integrators/integrators_gbaoab.dat')
+    try:
+        _nt.assert_almost_equal(system.positions, result[0:4], DECIMAL_D)
+        _nt.assert_almost_equal(system.velocities, result[4:8], DECIMAL_D)
+    except:
+        pass
+    else:
+        raise AssertionError
+    system = _h.get_harmonic_system()
+    c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
+         {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
+         {'type': 2, 'indices': [0, 1, 2, 3], 'target': 0, 'tolerance': 1E-14}]
+    system.constraints.appends(c)
+    integrator.bind_system(system)
+    somd.utils.rng.seed(1)
+    integrator.propagate()
+    _nt.assert_almost_equal(system.positions, result[0:4], DECIMAL_D)
+    _nt.assert_almost_equal(system.velocities, result[4:8], DECIMAL_D)
+
+
 def test_bdp():
     somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -6,7 +6,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_splitting():
@@ -169,7 +169,7 @@ def test_nhc_copy_integrator_rev_1():
 
 
 def test_obabo():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     integrator = somd.core.integrators.obabo_integrator(
         0.001, relaxation_times=[0.01])
@@ -181,7 +181,7 @@ def test_obabo():
 
 
 def test_baoab():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     integrator = somd.core.integrators.obabo_integrator(
         0.001, relaxation_times=[0.01])
@@ -193,7 +193,7 @@ def test_baoab():
 
 
 def test_gobabo():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
@@ -209,7 +209,7 @@ def test_gobabo():
 
 
 def test_gbaoab():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -225,14 +225,14 @@ def test_gbaoab():
 
 
 def test_gbaoab_copy_integrator():
-    rng = _np.random.RandomState(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
          {'type': 2, 'indices': [0, 1, 2, 3], 'target': 0, 'tolerance': 1E-14}]
     system.constraints.appends(c)
     i1 = somd.core.integrators.gbaoab_integrator(
-        0.0005, relaxation_times=[0.01], rng=rng)
+        0.0005, relaxation_times=[0.01])
     integrator = i1.copy()
     integrator.bind_system(system)
     integrator.propagate()
@@ -242,7 +242,7 @@ def test_gbaoab_copy_integrator():
 
 
 def test_gbaoab_copy_system():
-    rng = _np.random.RandomState(1)
+    somd.utils.rng.seed(1)
     s1 = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
@@ -252,7 +252,6 @@ def test_gbaoab_copy_system():
     system.potentials.append(s1.potentials[0])
     integrator = somd.core.integrators.gbaoab_integrator(
         0.0005, relaxation_times=[0.01])
-    integrator.rng = rng
     integrator.bind_system(system)
     integrator.propagate()
     result = _np.loadtxt('data/integrators/integrators_gbaoab.dat')
@@ -261,11 +260,11 @@ def test_gbaoab_copy_system():
 
 
 def test_bdp():
-    rng = _np.random.RandomState(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     integrator = somd.core.integrators.INTEGRATOR(
         0.0005, [{'operators': ['B', 'V', 'R', 'V', 'B']}],
-        relaxation_times=[0.01], rng=rng)
+        relaxation_times=[0.01])
     integrator.bind_system(system)
     integrator.propagate()
     result = _np.loadtxt('data/integrators/integrators_bdp.dat')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_parser_1():
@@ -43,7 +43,7 @@ def test_parser_1():
 
 
 def test_parser_2():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     indices = [68, 170, 183, 268, 370, 383]
     restart_function = somd.apps.simulations.SIMULATION.restart_from
     somd.apps.simulations.SIMULATION.restart_from = \

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -9,7 +9,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_nep():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -6,7 +6,7 @@ import numpy.testing as _nt
 
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_run_1():
@@ -27,7 +27,7 @@ def test_run_1():
 
 
 def test_run_2():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},
@@ -63,7 +63,7 @@ def test_restart_1():
 
 
 def test_restart_2():
-    _np.random.seed(1)
+    somd.utils.rng.seed(1)
     system = _h.get_harmonic_system()
     c = [{'type': 0, 'indices': [0, 1], 'target': 1.0, 'tolerance': 1E-14},
          {'type': 1, 'indices': [0, 1, 2], 'target': 1.57, 'tolerance': 1E-14},

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -6,7 +6,7 @@ import numpy.testing as _nt
 DECIMAL_F = 7
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_pdb():

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -7,7 +7,7 @@ import numpy.testing as _nt
 
 DECIMAL_D = 14
 
-_np.random.seed(1)
+somd.utils.rng = somd.utils._rng.LEGACYRNG(1)
 
 
 def test_trajectory_1():


### PR DESCRIPTION
In this PR, these breaking changes were made:

1. The `restart` trajectory writer was removed. Now all `h5` trajectories save NHC and RNG data of the last snapshot. Thus, the `is_restart_file` key in the TOML parser was removed as well.
2. The default RNG was changed from NumPy's legacy `RandomState` to `PCG64`.
3. The RNG data is now saved in an array inside the `h5` trajectory, instead of an attribute.

As a result, after this PR, SOMD will not be able to restart from old `restart` files. But I think the new RNG could bring better statistics, and the new standalone `RNG` class will be more robust against the possible parallel running feature in the future.